### PR TITLE
DOC: add rich as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fire
 loguru
 datasets
 typer
+rich


### PR DESCRIPTION
Fix the following error on documented install and bot run:

```
bencipollini@kitten MoA % python bot.py                  
pip Traceback (most recent call last):
  File "/Users/bencipollini/code/ref/MoA/bot.py", line 10, in <module>
    from rich import print
ModuleNotFoundError: No module named 'rich'
```

After adding `rich`, works!