### PR TITLE
fix(bot): fix a bug where references was a string instead of an array

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -62,6 +62,12 @@ def process_fn(
     """
 
     references = item.get("references", [])
+    # check if references is a string
+    if isinstance(references, str):
+        references = [references]
+    # filter out empty strings
+    references = [ref for ref in references if ref]
+
     model = item["model"]
     messages = item["instruction"]
 


### PR DESCRIPTION
Hello,

Firstly, thank you for this amazing resource. I've been reading about it and playing with the code all day to figure out how it all ties together. Amazing work! 🙌 

I did find a small bug, though. In the `process_fn` when it calls `generate_with_references` the `references` variable is sometimes just a string instead of an array. Because of this, when `inject_references_to_messages` in `utils.py` spreads it, it becomes a big mess.

I'm not a python developer, but with the help of Copilot I was able to produce this little fix that worked.

It's probably not the best PR to merge, but it should help you find the source of the bug. I'm suspecting the `eval_set = datasets.Dataset.from_dict(data)` is not working as expected.

Oh, to reproduce the bug, you need to set `rounds` to 2 or more so it actually generates reference material for the second layer.

Again, thank you for the research paper and this code, it's amazing 👏 